### PR TITLE
Added maintainer and paragraph

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,10 +4,12 @@ version=0.0.17
 license=DO WHAT YOU WANT PUBLIC LICENSE
 
 author=ITEAD / BSpranger / ScruffR
+maintainer=ScruffR et al.
 
-sentence=Nextion library provides an easy-to-use way to manipulate Nextion serial displays. 
+sentence=Nextion library provides an easy-to-use way to manipulate Nextion serial displays.
+paragraph=Users can use the libarry freely, either in commerical projects or open-source prjects, without any additional condiitons. For more information about the Nextion display project, please visit the wiki. The wiki provdies all the necessary technical documnets, quick start guide, tutorials, demos, as well as some useful resources. To get your Nextion display, please visit iMall. To discuss the project? Request new features? Report a BUG? please visit the Forums
+
 url=https://github.com/ScruffR/ITEADLIB_Nextion
 
 repository=https://github.com/ScruffR/ITEADLIB_Nextion
 .git
-


### PR DESCRIPTION
This fixes several errors that I got when trying to add the library to the Arduino IDE.

Error message: `Invalid library found in [path]: Missing 'maintainer' from library` (and the same with `paragraph`)